### PR TITLE
Remove redundant build flags

### DIFF
--- a/org.gnome.gitg.json
+++ b/org.gnome.gitg.json
@@ -27,8 +27,6 @@
         "--filesystem=xdg-run/keyring"
     ],
     "build-options" : {
-        "cflags": "-O2 -g",
-        "cxxflags": "-O2 -g",
         "env": {
             "V": "1"
         }


### PR DESCRIPTION
The 3.30 runtime sets these as defaults.