### PR TITLE
Don't cleanup typelib files

### DIFF
--- a/org.gnome.gitg.json
+++ b/org.gnome.gitg.json
@@ -21,8 +21,6 @@
     ],
     "cleanup": [
         "/include",
-        "/lib/girepository-1.0",
-        "/lib/peas-demo",
         "/lib/pkgconfig",
         "/man",
         "/share/aclocal",


### PR DESCRIPTION
Gitg depends on Peas-1.0.typelib at runtime. Looks like this slipped past my eyes.

```
(gitg:2): gitg-WARNING **: 10:58:10.924: gitg-plugins-engine.vala:40: Could not load repository: Typelib file for namespace 'Peas', version '1.0' not found
```

`/lib/peas-demo` is already cleaned up in the libpeas module, so removed that duplicate.

cc @albfan 