### PR TITLE
spelling mistake

### DIFF
--- a/org.gnome.gitg.json
+++ b/org.gnome.gitg.json
@@ -9,7 +9,7 @@
         "--share=ipc", "--socket=fallback-x11",
         /* Wayland access */
         "--socket=wayland",
-        /* Required fot push action */
+        /* Required for push action */
         "--socket=ssh-auth",
         /* Required for cloning repositories */
         "--share=network",


### PR DESCRIPTION
is host actually needed? Could this be switched to home and host be opt-in? or host being ro? Sooome more security?