### PR TITLE
enable ssh support on libgit2

### DIFF
--- a/org.gnome.gitg.json
+++ b/org.gnome.gitg.json
@@ -72,7 +72,8 @@
             "config-opts": [
                 "-DBUILD_SHARED_LIBS:BOOL=ON",
                 "-DBUILD_TESTS:BOOL=OFF",
-                "-DUSE_THREADS:BOOL=ON"
+                "-DUSE_THREADS:BOOL=ON",
+                "-DUSE_SSH:BOOL=ON"
             ],
             "sources": [
                 {


### PR DESCRIPTION
fixes #45 