### PR TITLE
draft: Update gitg runtime to 46

### DIFF
--- a/org.gnome.gitg.json
+++ b/org.gnome.gitg.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.gnome.gitg",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "45",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "command": "gitg",
     "finish-args": [

--- a/org.gnome.gitg.json
+++ b/org.gnome.gitg.json
@@ -198,8 +198,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.44.0.tar.xz",
-                    "sha256": "e358738dcb5b5ea340ce900a0015c03ae86e804e7ff64e47aa4631ddee681de3",
+                    "url": "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.45.2.tar.xz",
+                    "sha256": "51bfe87eb1c02fed1484051875365eeab229831d30d0cec5d89a14f9e40e9adb",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 5350,


### PR DESCRIPTION
- Update gitg runtime to 46 because runtime 45 will be EOL on 2024-09-14.
- Update git version to 2.45.2.