### PR TITLE
Mark libssh2 as a normal module

### DIFF
--- a/org.gnome.gitg.json
+++ b/org.gnome.gitg.json
@@ -59,7 +59,6 @@
                     "url": "https://www.libssh2.org/download/libssh2-1.11.0.tar.gz",
                     "sha256": "3736161e41e2693324deb38c26cfdc3efe6209d634ba4258db1cecff6a5ad461",
                     "x-checker-data": {
-                        "is-important": true,
                         "type": "anitya",
                         "project-id": 1730,
                         "url-template": "https://www.libssh2.org/download/libssh2-$version.tar.gz"


### PR DESCRIPTION
Flathubbot is trying to update to a newer version. Since the new current version does not contain any security issues, it is not an important update.